### PR TITLE
Enabled dark and light mode with switch for docs using docsify-darklight-theme with redesigned search bar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,12 @@
     <title>Xenus</title>
     <meta name="description" content="Description">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-    <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+    <link 
+      rel="stylesheet"
+      href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+      title="docsify-darklight-theme"
+      type="text/css"
+    />
     <link rel="icon" href="https://res.cloudinary.com/abellion/image/upload/v1535202916/icon_ofrkgv.png">
   </head>
 
@@ -25,7 +30,10 @@
       loadSidebar: false,
     }
   </script>
-
+  <script 
+    src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
+    type="text/javascript">
+  </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
   <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
 


### PR DESCRIPTION
Enabled dark and light mode with switch for docs using docsify-darklight-theme with redesigned search bar. For more customization [see here](https://boopathikumar018.github.io/docsify-darklight-theme)

**Light Mode :**

Before 

![image](https://user-images.githubusercontent.com/10001746/79610187-b50c4d00-8115-11ea-91d4-2b3cf07cd912.png)

After

![image](https://user-images.githubusercontent.com/10001746/79610235-cce3d100-8115-11ea-9d19-f4482b2a9a72.png)

**Dark Mode :**

![image](https://user-images.githubusercontent.com/10001746/79610280-e258fb00-8115-11ea-9d25-ad6c6ddbc098.png)


