### PR TITLE
Allow PHP8 and recent PHPUnit versions, bump minimum req to PHP 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "symfony/var-dumper": "^3.3",
-        "phpunit/phpunit": "~6.4"
+        "phpunit/phpunit": "^7.0|^8.0|^9.0"
     },
     "autoload": {
         "psr-4": { "Xenus\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "abellion/xenus",
     "description": "Xenus : A MongoDB ODM",
-    "keywords": ["php-7", "mongodb", "odm", "xenus"],
+    "keywords": ["php-7", "php-8", "mongodb", "odm", "xenus"],
     "type": "library",
     "license": "MIT",
     "authors": [
@@ -11,13 +11,13 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1|^8.0",
         "ext-mongodb": "^1.2.0",
         "mongodb/mongodb": "^1.1.0"
     },
     "require-dev": {
         "symfony/var-dumper": "^3.3",
-        "phpunit/phpunit": "^6.4"
+        "phpunit/phpunit": "~6.4"
     },
     "autoload": {
         "psr-4": { "Xenus\\": "src/" }

--- a/tests/Support/SetupTestsHooks.php
+++ b/tests/Support/SetupTestsHooks.php
@@ -9,7 +9,7 @@ trait SetupTestsHooks
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         foreach ($this->setup ?? [] as $setup) {
             call_user_func([$this, $setup]);
@@ -21,7 +21,7 @@ trait SetupTestsHooks
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach ($this->tearDown ?? [] as $tearDown) {
             call_user_func([$this, $tearDown]);


### PR DESCRIPTION
Hello,

Currently it's impossible to install the package on PHP8, due to composer limitation. Recent versions of PHPUnit also don't run the test suite, since the setUp() and tearDown() method have to explicitly declare their return value as void when overriding from PHPUnit.