### PR TITLE
BugFix ArrayAccess

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -74,7 +74,7 @@ class Document implements Iterator, ArrayAccess, JsonSerializable, Serializable,
      */
     public function has(string $offset)
     {
-        return isset($this->document[$offset]);
+        return array_key_exists($offset, $this->document);
     }
 
     /**

--- a/src/Document/ArrayAccess.php
+++ b/src/Document/ArrayAccess.php
@@ -72,6 +72,6 @@ trait ArrayAccess
      */
     public function offsetExists($offset): bool
     {
-        return isset($this->document[$offset]);
+        return array_key_exists($offset, $this->document);
     }
 }


### PR DESCRIPTION
The offsetExists function currently returns false on empty document fields (`null`). This could be fix by using array_key_exists instead of isset.