### PR TITLE
Connect document copies with their original collection

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -87,6 +87,7 @@ class Document implements Iterator, ArrayAccess, JsonSerializable, Serializable,
     public function with(array $fields)
     {
         $document = new static();
+        $document->collection = $this->collection;
         $document->document = [];
 
         foreach ($fields as $field) {
@@ -108,6 +109,7 @@ class Document implements Iterator, ArrayAccess, JsonSerializable, Serializable,
     public function without(array $fields)
     {
         $document = new static();
+        $document->collection = $this->collection;
         $document->document = [];
 
         foreach ($this->document as $key => $value) {

--- a/tests/Tests/DocumentTest.php
+++ b/tests/Tests/DocumentTest.php
@@ -3,9 +3,12 @@
 namespace Xenus\Tests\Tests;
 
 use Xenus\Document;
+use Xenus\Tests\Support\SetupCollectionTest;
 
 class DocumentTest extends \PHPUnit\Framework\TestCase
 {
+    use SetupCollectionTest;
+
     public function test_has_method()
     {
         $document = new Document([
@@ -85,6 +88,8 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
             protected $withId = true;
         };
 
+        $document->connect($this->cities);
+
         $document = $document->fill([
             'name' => 'Antoine', 'city' => 'Paris'
         ]);
@@ -100,6 +105,10 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             ['name' => 'Antoine'], $document->with(['name', 'unknown'])->toArray()
         );
+
+        $this->assertEquals(
+            $document->collection(), $document->with([])->collection()
+        );
     }
 
     public function test_without_method()
@@ -107,6 +116,8 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $document = new class extends Document {
             protected $withId = true;
         };
+
+        $document->connect($this->cities);
 
         $document = $document->fill([
             'name' => 'Antoine', 'city' => 'Paris'
@@ -118,6 +129,10 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(
             ['name' => 'Antoine', 'city' => 'Paris'], $document->without(['_id'])->toArray()
+        );
+
+        $this->assertEquals(
+            $document->collection(), $document->without([])->collection()
         );
     }
 


### PR DESCRIPTION
This changes the `Document::with` and `Document::without` methods to connect newly created documents to the same collection as that of the ones they derive from.