### PR TITLE
fix php deprecation warnings - php8.1

### DIFF
--- a/src/Document/MongoAccess.php
+++ b/src/Document/MongoAccess.php
@@ -7,8 +7,9 @@ trait MongoAccess
     /**
      * Serialize the document to a MongoDB readable value
      *
-     * @return array The document as array
+     * @return array|object The document as array
      */
+    #[\ReturnTypeWillChange]
     public function bsonSerialize()
     {
         return $this->document;
@@ -19,7 +20,7 @@ trait MongoAccess
      *
      * @param  array  $document The document as array
      */
-    public function bsonUnserialize(array $document)
+    public function bsonUnserialize(array $document): void
     {
         self::fillFromSetter($document);
     }


### PR DESCRIPTION
Hello guys,

The project I am working on is using PHP version 8.1. I am on version 0.19.2 of xenus package and I have noticed that there are few php deprecation errors, which I have resolved in a PR. 

Could someone please review it? Thank you.